### PR TITLE
[release-4.15] OCPBUGS-30298: fix: round down/up req/limit bytes to 4096 sector for sizes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -94,6 +94,13 @@ const DefaultSizeGb = 1
 // DefaultSize is DefaultSizeGb in bytes
 const DefaultSize = int64(DefaultSizeGb << 30)
 
+// MinimumSectorSize is the minimum size in bytes for volumes (PVC or generic ephemeral volumes).
+// It is derived from the usual sector size of 512,1024 or 4096 bytes for logical volumes.
+// While Sector Sizes of 512 are common, using 4096 is safe
+// As it also aligns with 512 and 1024 byte sectors, and is the default for most modern disks.
+// Going lower than this size will cause validation issues on volume creation for the user.
+const MinimumSectorSize = int64(4096)
+
 // Label key that indicates The controller/user who created this resource
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 const CreatedbyLabelKey = "app.kubernetes.io/created-by"


### PR DESCRIPTION
cherry-picked from commit c10420eaeb4310beff627ffb1974852a54aa4a07

Manual Cherry Pick Operation due to large diff
Ignored lvm_command_test as lvm rework prohibits backport otherwise.