### PR TITLE
OCPBUGS-49879: fix: lvmd: use 0 as free bytes of thin pool if usage exceeds total capacity

### DIFF
--- a/internal/lvmd/lvservice.go
+++ b/internal/lvmd/lvservice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/topolvm/topolvm/internal/lvmd/command"
 	"github.com/topolvm/topolvm/pkg/lvmd/proto"
@@ -79,7 +78,8 @@ func (s *lvService) CreateLV(ctx context.Context, req *proto.CreateLVRequest) (*
 			logger.Error(err, "failed to get free bytes")
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		free = uint64(math.Floor(dc.ThinPoolConfig.OverprovisionRatio*float64(tpu.SizeBytes))) - tpu.VirtualBytes
+		free = calcThinPoolFreeBytes(
+			dc.ThinPoolConfig.OverprovisionRatio, tpu.SizeBytes, tpu.VirtualBytes)
 	default:
 		// technically this block will not be hit however make sure we return error
 		// in such cases where deviceclass target is neither thick or thinpool
@@ -364,7 +364,8 @@ func (s *lvService) ResizeLV(ctx context.Context, req *proto.ResizeLVRequest) (*
 			logger.Error(err, "failed to get free bytes")
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		free = uint64(math.Floor(dc.ThinPoolConfig.OverprovisionRatio*float64(tpu.SizeBytes))) - tpu.VirtualBytes
+		free = calcThinPoolFreeBytes(
+			dc.ThinPoolConfig.OverprovisionRatio, tpu.SizeBytes, tpu.VirtualBytes)
 	default:
 		// technically this block will not be hit however make sure we return error
 		// in such cases where deviceclass target is neither thick or thinpool

--- a/internal/lvmd/util.go
+++ b/internal/lvmd/util.go
@@ -1,0 +1,11 @@
+package lvmd
+
+import "math"
+
+func calcThinPoolFreeBytes(overProvisionRatio float64, tpuSizeBytes, tpuVirtualBytes uint64) uint64 {
+	virtualPoolSize := uint64(math.Floor(overProvisionRatio * float64(tpuSizeBytes)))
+	if virtualPoolSize <= tpuVirtualBytes {
+		return 0
+	}
+	return virtualPoolSize - tpuVirtualBytes
+}

--- a/internal/lvmd/vgservice.go
+++ b/internal/lvmd/vgservice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 
 	"github.com/topolvm/topolvm/internal/lvmd/command"
@@ -121,7 +120,8 @@ func (s *vgService) GetFreeBytes(ctx context.Context, req *proto.GetFreeBytesReq
 		}
 
 		// freebytes available in thinpool considering the overprovisionratio
-		vgFree = uint64(math.Floor(dc.ThinPoolConfig.OverprovisionRatio*float64(tpu.SizeBytes))) - tpu.VirtualBytes
+		vgFree = calcThinPoolFreeBytes(
+			dc.ThinPoolConfig.OverprovisionRatio, tpu.SizeBytes, tpu.VirtualBytes)
 
 	default:
 		return nil, status.Error(codes.Internal, fmt.Sprintf("unsupported device class target: %s", dc.Type))
@@ -184,7 +184,8 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 			tpi.MetadataPercent = tpu.MetadataPercent
 
 			// used for annotating the node for capacity aware scheduling
-			opb := uint64(math.Floor(dc.ThinPoolConfig.OverprovisionRatio*float64(tpu.SizeBytes))) - tpu.VirtualBytes
+			opb := calcThinPoolFreeBytes(
+				dc.ThinPoolConfig.OverprovisionRatio, tpu.SizeBytes, tpu.VirtualBytes)
 			tpi.OverprovisionBytes = opb
 			if dc.Default {
 				res.FreeBytes = opb


### PR DESCRIPTION
manual cherry-pick of 4c669b9