### PR TITLE
NO-JIRA: fix: adding renovate.json to topolvm main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "gomod": {
+    "enabled": false
+  },
+  "pre-commit": {
+    "enabled": false
+  },
+  "commitBody": "Signed-off-by: {{{gitAuthor}}}",
+  "packageRules": [
+    {
+      "addLabels": [
+        "approved",
+        "lgtm"
+      ],
+      "autoApprove": true,
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "rebase",
+      "enabled": true,
+      "includePaths": [
+        "release/**"
+      ],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "platformAutomerge": true,
+      "commitMessagePrefix": "NO-JIRA:",
+      "schedule": [
+        "at any time"
+      ]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    }
+  ],
+  "prConcurrentLimit": 0,
+  "pruneBranchAfterAutomerge": true,
+  "pruneStaleBranches": true,
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "tekton": {
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "rebase",
+    "addLabels": [
+      "approved",
+      "lgtm"
+    ],
+    "enabled": true,
+    "fileMatch": [
+      "\\.yaml$",
+      "\\.yml$"
+    ],
+    "ignoreTests": true,
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "platformAutomerge": true,
+    "commitMessagePrefix": "NO-JIRA:"
+  }
+}


### PR DESCRIPTION
Renovate only looks at the main branch for the renovate config thus requiring us to add it to main